### PR TITLE
Module

### DIFF
--- a/blobstore/delete.go
+++ b/blobstore/delete.go
@@ -69,7 +69,7 @@ func (bh *BlobHandler) HandleDeleteObject(c echo.Context) error {
 	keyExist, err := bh.KeyExists(bucket, key)
 	if err != nil {
 		log.Errorf("HandleDeleteObjects: Error checking if key exists: %s", err.Error())
-		return c.JSON(http.StatusBadRequest, err)
+		return c.JSON(http.StatusInternalServerError, err)
 	}
 	if !keyExist {
 		err := fmt.Errorf("object %s not found", key)

--- a/blobstore/list.go
+++ b/blobstore/list.go
@@ -68,12 +68,14 @@ func (bh *BlobHandler) HandleListByPrefix(c echo.Context) error {
 		log.Error("HandleListByPrefix: " + err.Error())
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
+
 	if isObject {
 		objMeta, err := bh.GetMetaData(bucket, prefix)
 		if err != nil {
 			log.Error("HandleListByPrefix: " + err.Error())
 			return c.JSON(http.StatusInternalServerError, err.Error())
 		}
+		fmt.Println("is object? ", objMeta)
 		if *objMeta.ContentLength == 0 {
 			log.Infof("HandleListByPrefix: Detected a zero byte directory marker within prefix: %s", prefix)
 		} else {

--- a/blobstore/move.go
+++ b/blobstore/move.go
@@ -84,7 +84,11 @@ func (bh *BlobHandler) HandleMoveObject(c echo.Context) error {
 
 	err = bh.CopyObject(bucket, srcObjectKey, destObjectKey)
 	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
+		if strings.Contains(err.Error(), "keys are identical; no action taken") {
+			return c.JSON(http.StatusBadRequest, err.Error()) // 400 Bad Request
+		} else if strings.Contains(err.Error(), "already exists in the bucket; duplication will cause an overwrite") {
+			return c.JSON(http.StatusConflict, err.Error()) // 409 Conflict
+		} else if strings.Contains(err.Error(), "does not exist") {
 			return c.JSON(http.StatusNotFound, err.Error())
 		}
 		log.Error("HandleCopyObject: Error when implementing copyObject", err.Error())

--- a/blobstore/presigned_url.go
+++ b/blobstore/presigned_url.go
@@ -141,7 +141,7 @@ func (bh *BlobHandler) HandleGetPresignedURL(c echo.Context) error {
 	expPeriod, err := strconv.Atoi(os.Getenv("URL_EXP_DAYS"))
 	if err != nil {
 		log.Error("HandleGetPresignedURL: Error getting `URL_EXP_DAYS` from env file:", err.Error())
-		return c.JSON(http.StatusBadRequest, err.Error())
+		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 	url, err := bh.GetPresignedURL(bucket, key, expPeriod)
 	if err != nil {
@@ -207,7 +207,7 @@ func (bh *BlobHandler) HandleGetPresignedURLMultiObj(c echo.Context) error {
 	expPeriod, err := strconv.Atoi(os.Getenv("URL_EXP_DAYS"))
 	if err != nil {
 		log.Error("HandleGetPresignedURLMultiObj: Error getting `URL_EXP_DAYS` from env file:", err.Error())
-		return c.JSON(http.StatusBadRequest, err.Error())
+		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 	href, err := bh.GetPresignedURL(bucket, outputFile, expPeriod)
 	if err != nil {


### PR DESCRIPTION
- rename the module from `app` to `github.com/dewberry/s3api`
- Make stand-alone functions public so they can be used when the package is imported
- Refactor `HandleObjectContent`, `HandleGetMetadata`, and `HandleMovePrefix` to add their logic into stand-alone functions
- Resolve an issue where listing in S3 returned a `Teapot` error for valid prefixes. The problem was caused by mistaking valid prefixes for S3's zero-byte directory marker objects, which are used to represent empty directories.