### PR TITLE
add better error handeling for fatal scenarios

### DIFF
--- a/blobstore/blobhandler.go
+++ b/blobstore/blobhandler.go
@@ -62,10 +62,7 @@ func NewBlobHandler(envJson string) (*BlobHandler, error) {
 	// Load AWS credentials from the provided .env.json file
 	log.Debug("looking for .env.json")
 	awsConfig, err := newAWSConfig(envJson)
-	if os.Getenv("AWS_REGION") == "" {
-		errMsg := fmt.Errorf("no AWS_REGION variable found in env, variable required to initialize AWS sessions")
-		log.Fatal(errMsg.Error())
-	}
+
 	// Check if loading AWS credentials from .env.json failed
 	if err != nil {
 		log.Warnf("env.json credentials extraction failed, attmepting to retreive from environment, %s", err.Error())
@@ -132,6 +129,7 @@ func NewBlobHandler(envJson string) (*BlobHandler, error) {
 func aWSSessionManager(creds AWSCreds) (*s3.S3, *session.Session, error) {
 	log.Info("Using AWS S3")
 	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String("us-east-1"),
 		Credentials: credentials.NewStaticCredentials(creds.AWS_ACCESS_KEY_ID, creds.AWS_SECRET_ACCESS_KEY, ""),
 	})
 	if err != nil {
@@ -143,7 +141,7 @@ func aWSSessionManager(creds AWSCreds) (*s3.S3, *session.Session, error) {
 func minIOSessionManager(mc MinioConfig) (*s3.S3, *session.Session, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Endpoint:         aws.String(mc.S3Endpoint),
-		Region:           aws.String(mc.S3Region),
+		Region:           aws.String("us-east-1"),
 		Credentials:      credentials.NewStaticCredentials(mc.AccessKeyID, mc.SecretAccessKey, ""),
 		S3ForcePathStyle: aws.Bool(true),
 	})

--- a/blobstore/creds.go
+++ b/blobstore/creds.go
@@ -18,7 +18,6 @@ type AWSConfig struct {
 
 type MinioConfig struct {
 	S3Endpoint      string `json:"MINIO_S3_ENDPOINT"`
-	S3Region        string `json:"MINIO_S3_REGION"`
 	DisableSSL      string `json:"MINIO_S3_DISABLE_SSL"`
 	ForcePathStyle  string `json:"MINIO_S3_FORCE_PATH_STYLE"`
 	AccessKeyID     string `json:"MINIO_ACCESS_KEY_ID"`
@@ -46,9 +45,6 @@ func (creds MinioConfig) validateMinioConfig() error {
 	missingFields := []string{}
 	if creds.S3Endpoint == "" {
 		missingFields = append(missingFields, "S3Endpoint")
-	}
-	if creds.S3Region == "" {
-		missingFields = append(missingFields, "S3Region")
 	}
 	if creds.DisableSSL == "" {
 		missingFields = append(missingFields, "DisableSSL")
@@ -133,7 +129,6 @@ func awsFromENV() AWSCreds {
 func newMinioConfig() MinioConfig {
 	var mc MinioConfig
 	mc.S3Endpoint = os.Getenv("MINIO_S3_ENDPOINT")
-	mc.S3Region = os.Getenv("MINIO_S3_REGION")
 	mc.DisableSSL = os.Getenv("MINIO_S3_DISABLE_SSL")
 	mc.ForcePathStyle = os.Getenv("MINIO_S3_FORCE_PATH_STYLE")
 	mc.AccessKeyID = os.Getenv("MINIO_ACCESS_KEY_ID")


### PR DESCRIPTION
- Add default hard-coded `AWS_REGION` so that the user does not have to specify in the env
- Add the `AWS_ACCESS_KEY_ID` to the error for failed credentials