### PR TITLE
Limit presigned upload

### DIFF
--- a/blobstore/config.go
+++ b/blobstore/config.go
@@ -1,5 +1,5 @@
 package blobstore
 
 // these are the default values of limits if not predefined by user from env
-const defaultZipDownloadSizeLimit = 5    //gb
-const defaultScriptDownloadSizeLimit = 1 //gb
+const defaultZipDownloadSizeLimit = 5     //gb
+const defaultScriptDownloadSizeLimit = 50 //gb

--- a/blobstore/config.go
+++ b/blobstore/config.go
@@ -1,5 +1,5 @@
 package blobstore
 
 // these are the default values of limits if not predefined by user from env
-const defaultZipDownloadSizeLimit = 5     //gb
-const defaultScriptDownloadSizeLimit = 50 //gb
+const defaultZipDownloadSizeLimit = 5    //gb
+const defaultScriptDownloadSizeLimit = 1 //gb

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -124,6 +124,7 @@ func (bh *BlobHandler) HandleMultipartUpload(c echo.Context) error {
 	}
 
 	bucket := c.QueryParam("bucket")
+	//TODO: refactor check to use method
 	if bh.Config.AuthLevel > 0 {
 		claims, ok := c.Get("claims").(*auth.Claims)
 		if !ok {

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	e.GET("/object/content", auth.Authorize(bh.HandleObjectContents, allUsers...))
 	e.PUT("/object/move", auth.Authorize(bh.HandleMoveObject, admin...))
 	e.GET("/object/download", auth.Authorize(bh.HandleGetPresignedDownloadURL, allUsers...))
-	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...))
+	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...)) //deprecated
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, allUsers...))

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...)) //deprecated
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
-	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, allUsers...))
+	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))
 	// prefix
 	e.GET("/prefix/list", auth.Authorize(bh.HandleListByPrefix, allUsers...))
 	e.GET("/prefix/list_with_details", auth.Authorize(bh.HandleListByPrefixWithDetail, allUsers...))

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	e.GET("/object/content", auth.Authorize(bh.HandleObjectContents, allUsers...))
 	e.PUT("/object/move", auth.Authorize(bh.HandleMoveObject, admin...))
 	e.GET("/object/download", auth.Authorize(bh.HandleGetPresignedDownloadURL, allUsers...))
-	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...)) //deprecated
+	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...)) //deprecated by presigned upload URL
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))


### PR DESCRIPTION
- Change presigned upload URL endpoint to only allow writers 
- Add FGAC to presigned  upload URL 