### PR TITLE
Bug fix 5gb upload limit

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -4,7 +4,7 @@ S3API_SERVICE_PORT='5005'
 
 ## Auth:
 KEYCLOAK_PUBLIC_KEYS_URL='public-keys-url-string'
-AUTH_LEVEL=1                                      # Options: [0, 1] corresponds to [no FGAC, FGAC].
+AUTH_LEVEL=1                                      # Options: [0, 1] corresponds to [no FGAC, FGAC]. This integer value configures the initialization mode in docker-compose.
 AUTH_LIMITED_WRITER_ROLE='s3_limited_writer'
 
 ## DB for Auth:
@@ -14,7 +14,7 @@ POSTGRES_USER=user
 POSTGRES_DB=db
 PG_LOG_CHECKPOINTS='off'
 
-S3_MOCK=0 ##  Options: [0, 1] corresponds to [no s3 mock, s3 mock].
+S3_MOCK=0 ##  Options: [0, 1] corresponds to [no S3 Mock, s3 Mock]. This integer value configures the initialization mode in docker-compose.
 #### Optional:
 
 ## MINIO

--- a/.example.env
+++ b/.example.env
@@ -33,7 +33,7 @@ POSTGRES_DB=db
 PG_LOG_CHECKPOINTS='off'
 
 #for getting presigned Download URL
-URL_EXP_DAYS=7
+DOWNLOAD_URL_EXP_DAYS=7
 
 #for getting presigned Upload URL
 UPLOAD_URL_EXP_MIN = 15

--- a/.example.env
+++ b/.example.env
@@ -5,11 +5,6 @@ S3API_SERVICE_PORT='5005'
 ## Auth:
 KEYCLOAK_PUBLIC_KEYS_URL='public-keys-url-string'
 
-#for getting presigned URL
-URL_EXP_DAYS=7
-#temp subprefix in bucket that will be written to when arhicving and zippping
-TEMP_PREFIX='downloads-temp'
-
 # Auth
 AUTH_LEVEL='1'                                      # Options: [0, 1] corresponds to [no FGAC, FGAC] (Optional).
 AUTH_LIMITED_WRITER_ROLE='s3_limited_writer'
@@ -36,3 +31,11 @@ POSTGRES_PASSWORD=password
 POSTGRES_USER=user
 POSTGRES_DB=db
 PG_LOG_CHECKPOINTS='off'
+
+#for getting presigned Download URL
+URL_EXP_DAYS=7
+
+#for getting presigned Upload URL
+UPLOAD_URL_EXP_MIN = 15
+#temp subprefix in bucket that will be written to when arhicving and zippping
+TEMP_PREFIX='downloads-temp'

--- a/.example.env
+++ b/.example.env
@@ -1,19 +1,23 @@
-##### required
+#### Required:
 
 S3API_SERVICE_PORT='5005'
 
 ## Auth:
 KEYCLOAK_PUBLIC_KEYS_URL='public-keys-url-string'
-
-# Auth
 AUTH_LEVEL='1'                                      # Options: [0, 1] corresponds to [no FGAC, FGAC] (Optional).
 AUTH_LIMITED_WRITER_ROLE='s3_limited_writer'
 
+## DB for Auth:
+POSTGRES_CONN_STRING='postgres://user:password@postgres:5432/db?sslmode=disable'
+POSTGRES_PASSWORD=password
+POSTGRES_USER=user
+POSTGRES_DB=db
+PG_LOG_CHECKPOINTS='off'
 
-##### optional
 
-# MINIO
+#### Optional:
 
+## MINIO
 MINIO_S3_ENDPOINT='http://minio:9000'
 MINIO_S3_REGION='s3-region-string'
 MINIO_S3_DISABLE_SSL='bool-string'
@@ -21,22 +25,18 @@ MINIO_S3_FORCE_PATH_STYLE='bool-string'
 MINIO_SECRET_ACCESS_KEY='access-key-string'
 S3_MOCK='true'
 
-#download size limits (optional will default to 5 and 50 respectively)
+## Download size limits (optional will default to 5 and 50 respectively)
 ZIP_DOWNLOAD_SIZE_LIMIT = 5 #gb
 SCRIPT_DOWNLOAD_SIZE_LIMIT = 50 #gb
-#for getting presigned Download URL
+
+## For getting presigned Download URL
 DOWNLOAD_URL_EXP_DAYS=7
-#for getting presigned Upload URL
+
+## For getting presigned Upload URL
 UPLOAD_URL_EXP_MIN = 15
-#temp subprefix in bucket that will be written to when arhicving and zippping
+
+## Temp subprefix in bucket that will be written to when arhicving and zippping
 TEMP_PREFIX='downloads-temp'
-#set Log Level, will default to debug
+
+## Set Log Level, will default to debug
 LOG_LEVEL='debug'
-
-# --- PostgreSQL
-POSTGRES_CONN_STRING='postgres://user:password@postgres:5432/db?sslmode=disable'
-POSTGRES_PASSWORD=password
-POSTGRES_USER=user
-POSTGRES_DB=db
-PG_LOG_CHECKPOINTS='off'
-

--- a/.example.env
+++ b/.example.env
@@ -4,7 +4,7 @@ S3API_SERVICE_PORT='5005'
 
 ## Auth:
 KEYCLOAK_PUBLIC_KEYS_URL='public-keys-url-string'
-AUTH_LEVEL='1'                                      # Options: [0, 1] corresponds to [no FGAC, FGAC] (Optional).
+AUTH_LEVEL=1                                      # Options: [0, 1] corresponds to [no FGAC, FGAC].
 AUTH_LIMITED_WRITER_ROLE='s3_limited_writer'
 
 ## DB for Auth:
@@ -14,7 +14,7 @@ POSTGRES_USER=user
 POSTGRES_DB=db
 PG_LOG_CHECKPOINTS='off'
 
-
+S3_MOCK=0 ##  Options: [0, 1] corresponds to [no s3 mock, s3 mock].
 #### Optional:
 
 ## MINIO
@@ -23,7 +23,6 @@ MINIO_S3_REGION='s3-region-string'
 MINIO_S3_DISABLE_SSL='bool-string'
 MINIO_S3_FORCE_PATH_STYLE='bool-string'
 MINIO_SECRET_ACCESS_KEY='access-key-string'
-S3_MOCK='true'
 
 ## Download size limits (optional will default to 5 and 50 respectively)
 ZIP_DOWNLOAD_SIZE_LIMIT = 5 #gb

--- a/.example.env
+++ b/.example.env
@@ -9,7 +9,8 @@ KEYCLOAK_PUBLIC_KEYS_URL='public-keys-url-string'
 AUTH_LEVEL='1'                                      # Options: [0, 1] corresponds to [no FGAC, FGAC] (Optional).
 AUTH_LIMITED_WRITER_ROLE='s3_limited_writer'
 
-## optional
+
+##### optional
 
 # MINIO
 
@@ -23,6 +24,13 @@ S3_MOCK='true'
 #download size limits (optional will default to 5 and 50 respectively)
 ZIP_DOWNLOAD_SIZE_LIMIT = 5 #gb
 SCRIPT_DOWNLOAD_SIZE_LIMIT = 50 #gb
+#for getting presigned Download URL
+DOWNLOAD_URL_EXP_DAYS=7
+#for getting presigned Upload URL
+UPLOAD_URL_EXP_MIN = 15
+#temp subprefix in bucket that will be written to when arhicving and zippping
+TEMP_PREFIX='downloads-temp'
+#set Log Level, will default to debug
 LOG_LEVEL='debug'
 
 # --- PostgreSQL
@@ -32,10 +40,3 @@ POSTGRES_USER=user
 POSTGRES_DB=db
 PG_LOG_CHECKPOINTS='off'
 
-#for getting presigned Download URL
-DOWNLOAD_URL_EXP_DAYS=7
-
-#for getting presigned Upload URL
-UPLOAD_URL_EXP_MIN = 15
-#temp subprefix in bucket that will be written to when arhicving and zippping
-TEMP_PREFIX='downloads-temp'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,8 +27,6 @@ jobs:
           echo MINIO_SECRET_ACCESS_KEY=password >> .env
           echo MINIO_S3_REGION='us-east-1' >> .env
           echo S3_MOCK='true' >> .env
-          echo DOWNLOAD_URL_EXP_DAYS='7' >> .env
-          echo TEMP_PREFIX='downloads-temp' >> .env
           echo AWS_S3_BUCKET='test-bucket' >> .env
           echo S3API_SERVICE_PORT='5005' >> .env
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,7 +26,7 @@ jobs:
           echo MINIO_ACCESS_KEY_ID=user >> .env
           echo MINIO_SECRET_ACCESS_KEY=password >> .env
           echo MINIO_S3_REGION='us-east-1' >> .env
-          echo S3_MOCK='true' >> .env
+          echo S3_MOCK=1 >> .env
           echo AWS_S3_BUCKET='test-bucket' >> .env
           echo S3API_SERVICE_PORT='5005' >> .env
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,7 +27,7 @@ jobs:
           echo MINIO_SECRET_ACCESS_KEY=password >> .env
           echo MINIO_S3_REGION='us-east-1' >> .env
           echo S3_MOCK='true' >> .env
-          echo URL_EXP_DAYS='7' >> .env
+          echo DOWNLOAD_URL_EXP_DAYS='7' >> .env
           echo TEMP_PREFIX='downloads-temp' >> .env
           echo AWS_S3_BUCKET='test-bucket' >> .env
           echo S3API_SERVICE_PORT='5005' >> .env

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -29,7 +29,7 @@ jobs:
           echo S3_MOCK=1 >> .env
           echo AWS_S3_BUCKET='test-bucket' >> .env
           echo S3API_SERVICE_PORT='5005' >> .env
-
+          echo AUTH_LEVEL=0 >> .env
           echo POSTGRES_CONN_STRING='postgres://user:password@postgres:5432/db?sslmode=disable' >> .env
           echo POSTGRES_PASSWORD='password' >> .env
           echo POSTGRES_USER='user' >> .env

--- a/blobstore/blobhandler.go
+++ b/blobstore/blobhandler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/Dewberry/s3api/auth"
@@ -62,9 +63,17 @@ func NewBlobHandler(envJson string, authLvl int) (*BlobHandler, error) {
 		}
 		config.DB = db
 	}
-
+	s3MockStr := os.Getenv("S3_MOCK")
+	var s3Mock int
+	if s3MockStr == "" {
+		s3Mock = 0
+	}
+	s3Mock, err := strconv.Atoi(s3MockStr)
+	if err != nil {
+		log.Fatalf("could not convert S3_MOCK env variable to integer: %v", err)
+	}
 	// Check if the S3_MOCK environment variable is set to "true"
-	if os.Getenv("S3_MOCK") == "true" {
+	if s3Mock == 1 {
 		log.Info("Using MinIO")
 
 		// Load MinIO credentials from environment

--- a/blobstore/blobhandler.go
+++ b/blobstore/blobhandler.go
@@ -26,10 +26,13 @@ type S3Controller struct {
 type Config struct {
 	// Only settings that are typically environment-specific and can be loaded from
 	// external sources like configuration files, environment variables should go here.
-
-	AuthLevel int
-
-	LimitedWriterRoleName string
+	AuthLevel                             int
+	LimitedWriterRoleName                 string
+	DefaultTempPrefix                     string
+	DefaultDownloadPresignedUrlExpiration int
+	DefaultUploadPresignedUrlExpiration   int
+	DefaultScriptDownloadSizeLimit        int
+	DefaultZipDownloadSizeLimit           int
 }
 
 // Store configuration for the handler
@@ -45,9 +48,7 @@ type BlobHandler struct {
 func NewBlobHandler(envJson string, authLvl int) (*BlobHandler, error) {
 	// Create a new BlobHandler configuration
 	config := BlobHandler{
-		Config: &Config{
-			LimitedWriterRoleName: os.Getenv("AUTH_LIMITED_WRITER_ROLE"),
-		},
+		Config: newConfig(authLvl),
 	}
 
 	if authLvl > 0 {

--- a/blobstore/config.go
+++ b/blobstore/config.go
@@ -1,6 +1,51 @@
 package blobstore
 
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
 // these are the default values of limits if not predefined by user from env
-const defaultZipDownloadSizeLimit = 5          //gb
-const defaultScriptDownloadSizeLimit = 50      //gb
-const defaultUploadPresignedUrlExpiration = 15 //minutes
+const (
+	defaultZipDownloadSizeLimit           = 5                //gb
+	defaultScriptDownloadSizeLimit        = 50               //gb
+	defaultUploadPresignedUrlExpiration   = 15               //minutes
+	defaultDownloadPresignedUrlExpiration = 7                //days
+	defaultTempPrefix                     = "downloads-temp" //prefix
+)
+
+func newConfig(authLvl int) *Config {
+	c := &Config{
+		AuthLevel:                             authLvl,
+		LimitedWriterRoleName:                 os.Getenv("AUTH_LIMITED_WRITER_ROLE"),
+		DefaultTempPrefix:                     getEnvOrDefault("TEMP_PREFIX", defaultTempPrefix),
+		DefaultDownloadPresignedUrlExpiration: getIntEnvOrDefault("DOWNLOAD_URL_EXP_DAYS", defaultDownloadPresignedUrlExpiration),
+		DefaultUploadPresignedUrlExpiration:   getIntEnvOrDefault("UPLOAD_URL_EXP_MIN", defaultUploadPresignedUrlExpiration),
+		DefaultScriptDownloadSizeLimit:        getIntEnvOrDefault("SCRIPT_DOWNLOAD_SIZE_LIMIT", defaultScriptDownloadSizeLimit),
+		DefaultZipDownloadSizeLimit:           getIntEnvOrDefault("ZIP_DOWNLOAD_SIZE_LIMIT", defaultZipDownloadSizeLimit),
+	}
+	return c
+}
+
+// getEnvOrDefault returns the value of an environment variable or a default value if not set
+func getEnvOrDefault(envKey string, defaultValue string) string {
+	if value, exists := os.LookupEnv(envKey); exists {
+		return value
+	}
+	return defaultValue
+}
+
+// getIntEnvOrDefault does the same as getEnvOrDefault but for integer values
+func getIntEnvOrDefault(envKey string, defaultValue int) int {
+	valueStr, exists := os.LookupEnv(envKey)
+	if !exists {
+		return defaultValue
+	}
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		log.Printf("Error parsing %s, defaulting to %v: %v", envKey, defaultValue, err)
+		return defaultValue
+	}
+	return value
+}

--- a/blobstore/config.go
+++ b/blobstore/config.go
@@ -1,9 +1,10 @@
 package blobstore
 
 import (
-	"log"
 	"os"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // these are the default values of limits if not predefined by user from env
@@ -44,7 +45,7 @@ func getIntEnvOrDefault(envKey string, defaultValue int) int {
 	}
 	value, err := strconv.Atoi(valueStr)
 	if err != nil {
-		log.Printf("Error parsing %s, defaulting to %v: %v", envKey, defaultValue, err)
+		log.Debugf("Error parsing %s, defaulting to %v: %v", envKey, defaultValue, err)
 		return defaultValue
 	}
 	return value

--- a/blobstore/config.go
+++ b/blobstore/config.go
@@ -1,5 +1,6 @@
 package blobstore
 
 // these are the default values of limits if not predefined by user from env
-const defaultZipDownloadSizeLimit = 5     //gb
-const defaultScriptDownloadSizeLimit = 50 //gb
+const defaultZipDownloadSizeLimit = 5          //gb
+const defaultScriptDownloadSizeLimit = 50      //gb
+const defaultUploadPresignedUrlExpiration = 15 //minutes

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -294,7 +294,7 @@ func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (str
 }
 
 // endpoint handler that will return a MultiPart upload ID
-func (bh *BlobHandler) HandleGetMultiPartUploadID(c echo.Context) error {
+func (bh *BlobHandler) HandleGetMultipartUploadID(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
 		errMsg := fmt.Errorf("`key` parameters are required")

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -262,7 +262,7 @@ func (bh *BlobHandler) HandleGetPresignedUploadURL(c echo.Context) error {
 		}
 		log.Infof("successfully generated presigned part URL for key: %s", key)
 		return c.JSON(http.StatusOK, presignedURL)
-	} else if uploadID == "" || partNumberStr == "" {
+	} else if (uploadID == "" && partNumberStr != "") || (uploadID != "" && partNumberStr == "") {
 		errMsg := fmt.Errorf("both 'uploadID' and 'partNumber' must be provided together for a multipart upload, or neither for a standard upload")
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusUnprocessableEntity, errMsg.Error())

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -226,9 +226,9 @@ func (s3Ctrl *S3Controller) GetUploadPartPresignedURL(bucket string, key string,
 func (bh *BlobHandler) HandleGetPresignedUploadURL(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
-		err := errors.New("`key` parameters are required")
-		log.Error("HandleGeneratePresignedURL: " + err.Error())
-		return c.JSON(http.StatusUnprocessableEntity, err.Error())
+		errMsg := fmt.Errorf("`key` parameters are required")
+		log.Error(errMsg.Error())
+		return c.JSON(http.StatusUnprocessableEntity, errMsg.Error())
 	}
 	bucket := c.QueryParam("bucket")
 	httpCode, err := bh.CheckUserS3WritePermission(c, bucket, key)
@@ -293,9 +293,9 @@ func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (str
 func (bh *BlobHandler) HandleGetMultiPartUploadID(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
-		err := errors.New("`key` parameters are required")
-		log.Error("HandleGeneratePresignedURL: " + err.Error())
-		return c.JSON(http.StatusUnprocessableEntity, err.Error())
+		errMsg := fmt.Errorf("`key` parameters are required")
+		log.Error(errMsg.Error())
+		return c.JSON(http.StatusUnprocessableEntity, errMsg.Error())
 	}
 	bucket := c.QueryParam("bucket")
 	httpCode, err := bh.CheckUserS3WritePermission(c, bucket, key)
@@ -340,9 +340,9 @@ func (s3Ctrl *S3Controller) CompleteMultipartUpload(bucket string, key string, u
 func (bh *BlobHandler) HandleCompleteMultipartUpload(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
-		err := errors.New("`key` parameters are required")
-		log.Error("HandleGeneratePresignedURL: " + err.Error())
-		return c.JSON(http.StatusUnprocessableEntity, err.Error())
+		errMsg := fmt.Errorf("`key` parameters are required")
+		log.Error(errMsg.Error())
+		return c.JSON(http.StatusUnprocessableEntity, errMsg.Error())
 	}
 	bucket := c.QueryParam("bucket")
 	s3Ctrl, err := bh.GetController(bucket)

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -280,7 +280,7 @@ func (bh *BlobHandler) HandleGetPresignedUploadURL(c echo.Context) error {
 	return c.JSON(http.StatusOK, presignedURL)
 }
 
-// function that will return a Multipart upload ID
+// function that will return a multipart upload ID
 func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (string, error) {
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: aws.String(bucket),
@@ -293,7 +293,7 @@ func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (str
 	return *result.UploadId, nil
 }
 
-// endpoint handler that will return a MultiPart upload ID
+// endpoint handler that will return a multipart upload ID
 func (bh *BlobHandler) HandleGetMultipartUploadID(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
@@ -318,11 +318,11 @@ func (bh *BlobHandler) HandleGetMultipartUploadID(c echo.Context) error {
 
 	uploadID, err := s3Ctrl.GetMultiPartUploadID(bucket, key)
 	if err != nil {
-		errMsg := fmt.Errorf("error retrieving MultiPart Upload ID: %s", err.Error())
+		errMsg := fmt.Errorf("error retrieving multipart Upload ID: %s", err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}
-	log.Infof("successfully generated MultiPart Upload ID for key: %s", key)
+	log.Infof("successfully generated multipart Upload ID for key: %s", key)
 	return c.JSON(http.StatusOK, uploadID)
 }
 
@@ -360,7 +360,7 @@ func (bh *BlobHandler) HandleCompleteMultipartUpload(c echo.Context) error {
 	}
 	httpCode, err := bh.CheckUserS3WritePermission(c, bucket, key)
 	if err != nil {
-		errMsg := fmt.Errorf("error while checking for user permission: %s", err)
+		errMsg := fmt.Errorf("error while checking for user permission: %s", err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(httpCode, errMsg.Error())
 	}
@@ -393,7 +393,7 @@ func (bh *BlobHandler) HandleCompleteMultipartUpload(c echo.Context) error {
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}
-	log.Infof("succesfully completed multipart upload for ey %s", key)
+	log.Infof("succesfully completed multipart upload for key %s", key)
 	return c.JSON(http.StatusOK, "succesfully completed multipart upload")
 }
 
@@ -442,10 +442,10 @@ func (bh *BlobHandler) HandleAbortMultipartUpload(c echo.Context) error {
 
 	err = s3Ctrl.AbortMultipartUpload(bucket, key, uploadID)
 	if err != nil {
-		errMsg := fmt.Errorf("error aborting the multipart Upload for key %s, %s", key, err)
+		errMsg := fmt.Errorf("error aborting the multipart Upload for key %s, %s", key, err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}
-	log.Infof("succesfully aborted multipart upload for ey %s", key)
+	log.Infof("succesfully aborted multipart upload for key %s", key)
 	return c.JSON(http.StatusOK, "succesfully aborted multipart upload")
 }

--- a/blobstore/upload.go
+++ b/blobstore/upload.go
@@ -280,7 +280,7 @@ func (bh *BlobHandler) HandleGetPresignedUploadURL(c echo.Context) error {
 	return c.JSON(http.StatusOK, presignedURL)
 }
 
-// function that will return a Multipart upload ID
+// function that will return a multipart upload ID
 func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (string, error) {
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: aws.String(bucket),
@@ -293,7 +293,7 @@ func (s3Ctrl *S3Controller) GetMultiPartUploadID(bucket string, key string) (str
 	return *result.UploadId, nil
 }
 
-// endpoint handler that will return a MultiPart upload ID
+// endpoint handler that will return a multipart upload ID
 func (bh *BlobHandler) HandleGetMultipartUploadID(c echo.Context) error {
 	key := c.QueryParam("key")
 	if key == "" {
@@ -317,11 +317,11 @@ func (bh *BlobHandler) HandleGetMultipartUploadID(c echo.Context) error {
 	}
 	uploadID, err := s3Ctrl.GetMultiPartUploadID(bucket, key)
 	if err != nil {
-		errMsg := fmt.Errorf("error retrieving MultiPart Upload ID: %s", err.Error())
+		errMsg := fmt.Errorf("error retrieving multipart Upload ID: %s", err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}
-	log.Infof("successfully generated MultiPart Upload ID for key: %s", key)
+	log.Infof("successfully generated multipart Upload ID for key: %s", key)
 	return c.JSON(http.StatusOK, uploadID)
 }
 
@@ -388,11 +388,11 @@ func (bh *BlobHandler) HandleCompleteMultipartUpload(c echo.Context) error {
 
 	_, err = s3Ctrl.CompleteMultipartUpload(bucket, key, req.UploadID, s3Parts)
 	if err != nil {
-		errMsg := fmt.Errorf("error completing the multipart Upload for key %s, %s", key, err)
+		errMsg := fmt.Errorf("error completing the multipart Upload for key %s, %s", key, err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}
-	log.Infof("succesfully completed multipart upload for ey %s", key)
+	log.Infof("succesfully completed multipart upload for key %s", key)
 	return c.JSON(http.StatusOK, "succesfully completed multipart upload")
 }
 
@@ -441,7 +441,7 @@ func (bh *BlobHandler) HandleAbortMultipartUpload(c echo.Context) error {
 
 	err = s3Ctrl.AbortMultipartUpload(bucket, key, uploadID)
 	if err != nil {
-		errMsg := fmt.Errorf("error aborting the multipart Upload for key %s, %s", key, err)
+		errMsg := fmt.Errorf("error aborting the multipart Upload for key %s, %s", key, err.Error())
 		log.Error(errMsg.Error())
 		return c.JSON(http.StatusInternalServerError, errMsg.Error())
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - MINIO_ROOT_USER=user
       - MINIO_ROOT_PASSWORD=password
     command: server /data --console-address ":9001"
+    deploy:
+      replicas: $S3_MOCK
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -38,12 +40,18 @@ services:
   postgres:
     container_name: s3api_postgres
     image: postgres:16.1-alpine3.18
+    deploy:
+      replicas: $AUTH_LEVEL
     env_file:
       - .env
     ports:
       - '5432:5432'
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
+      test:
+        [
+          'CMD-SHELL',
+          'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB'
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/env-checker/env_checker.go
+++ b/env-checker/env_checker.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-var REQUIRED_ENV_VAR = []string{"S3API_SERVICE_PORT", "KEYCLOAK_PUBLIC_KEYS_URL", "URL_EXP_DAYS", "TEMP_PREFIX"}
+var REQUIRED_ENV_VAR = []string{"S3API_SERVICE_PORT", "KEYCLOAK_PUBLIC_KEYS_URL"}
 
 func CheckEnvVariablesExist(envVars []string) error {
 	var missingVars []string

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ func main() {
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))
 	e.GET("/object/multi_part_upload_id", auth.Authorize(bh.HandleGetMultiPartUploadID, writers...))
 	e.POST("/object/complete_multi_part_upload", auth.Authorize(bh.HandleCompleteMultipartUpload, writers...))
+	e.POST("object/abort_multi_part_upload", auth.Authorize(bh.HandleAbortMultipartUpload, writers...))
 	// prefix
 	e.GET("/prefix/list", auth.Authorize(bh.HandleListByPrefix, allUsers...))
 	e.GET("/prefix/list_with_details", auth.Authorize(bh.HandleListByPrefixWithDetail, allUsers...))

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...))
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
-	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, allUsers...))
+	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))
 	e.GET("/object/multi_part_upload_id", auth.Authorize(bh.HandleGetMultiPartUploadID, writers...))
 	e.POST("/object/complete_multi_part_upload", auth.Authorize(bh.HandleCompleteMultipartUpload, writers...))
 	// prefix

--- a/main.go
+++ b/main.go
@@ -49,12 +49,15 @@ func main() {
 		if err != nil {
 			log.Fatalf("could not convert AUTH_LEVEL env variable to integer: %v", err)
 		}
-		s3LimitWriterRoleName, ok := os.LookupEnv("AUTH_LIMITED_WRITER_ROLE")
-		if !ok {
-			log.Fatal("AUTH_S3_LIMITED_WRITER env variable not set")
+		if authLvl == 1 {
+			s3LimitWriterRoleName, ok := os.LookupEnv("AUTH_LIMITED_WRITER_ROLE")
+			if !ok {
+				log.Fatal("AUTH_S3_LIMITED_WRITER env variable not set")
+			}
+			allUsers = append(allUsers, s3LimitWriterRoleName)
+			writers = append(writers, s3LimitWriterRoleName)
 		}
-		allUsers = append(allUsers, s3LimitWriterRoleName)
-		writers = append(writers, s3LimitWriterRoleName)
+
 	}
 
 	envJson := "/app/.env.json"

--- a/main.go
+++ b/main.go
@@ -84,9 +84,9 @@ func main() {
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))
-	e.GET("/object/multi_part_upload_id", auth.Authorize(bh.HandleGetMultiPartUploadID, writers...))
-	e.POST("/object/complete_multi_part_upload", auth.Authorize(bh.HandleCompleteMultipartUpload, writers...))
-	e.POST("object/abort_multi_part_upload", auth.Authorize(bh.HandleAbortMultipartUpload, writers...))
+	e.GET("/object/multipart_upload_id", auth.Authorize(bh.HandleGetMultipartUploadID, writers...))
+	e.POST("/object/complete_multipart_upload", auth.Authorize(bh.HandleCompleteMultipartUpload, writers...))
+	e.POST("object/abort_multipart_upload", auth.Authorize(bh.HandleAbortMultipartUpload, writers...))
 	// prefix
 	e.GET("/prefix/list", auth.Authorize(bh.HandleListByPrefix, allUsers...))
 	e.GET("/prefix/list_with_details", auth.Authorize(bh.HandleListByPrefixWithDetail, allUsers...))

--- a/main.go
+++ b/main.go
@@ -84,6 +84,8 @@ func main() {
 	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, allUsers...))
+	e.GET("/object/multi_part_upload_id", auth.Authorize(bh.HandleGetMultiPartUploadID, writers...))
+	e.POST("/object/complete_multi_part_upload", auth.Authorize(bh.HandleCompleteMultipartUpload, writers...))
 	// prefix
 	e.GET("/prefix/list", auth.Authorize(bh.HandleListByPrefix, allUsers...))
 	e.GET("/prefix/list_with_details", auth.Authorize(bh.HandleListByPrefixWithDetail, allUsers...))


### PR DESCRIPTION
- Add Multipart endpoints to be used on the front end with pre-signed upload URLs.
    -  `object/presigned_upload` now accepts an optional upload ID and part number to generate upload URLs specific to multipart
    - `object/multi_part_upload_id` generates multipart upload id and returns to the user 
    - `object/complete_multi_part_upload` completes a multipart upload when all parts finish uploading 
    - `object/abort_multi_part_upload` aborts a multipart upload that was in progress and has wither failed or been manually cancelled by the user
- enhance config variable extraction, by making `ZIP_DOWNLOAD_SIZE_LIMIT`, `SCRIPT_DOWNLOAD_SIZE_LIMIT`, `DOWNLOAD_URL_EXP_DAYS`, `UPLOAD_URL_EXP_MIN` and `TEMP_PREFIX` optional and have a default value set up in a config file. If the user does not provide those variables in the env, it will default to default values. These variables are now extracted and added to the config field so they are not continually extracted and cast.
- Refactored the FGAC check within an endpoint by putting the logic in `CheckUserS3WritePermission`
- Make the `MINIO` and `Postgres` services be conditionally initialized based on env variables. If the `AUTH_LEVEL` is set to 0, meaning the API starts with no `FGAC`, then the `Postgres` instance will not be initialized. Same thing with `MINIO` and its env var `S3_MOCK`.