### PR TITLE
Discard 0 byte placeholder object when listing

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -123,7 +123,7 @@ func validateToken(tokenString string) (*Claims, error) {
 	return claims, nil
 }
 
-func overlap(s1 []string, s2 []string) bool {
+func Overlap(s1 []string, s2 []string) bool {
 	for _, x := range s1 {
 		for _, y := range s2 {
 			if x == y {
@@ -164,7 +164,7 @@ func Authorize(handler echo.HandlerFunc, allowedRoles ...string) echo.HandlerFun
 		// Store the claims in the echo.Context
 		c.Set("claims", claims)
 
-		ok := overlap(claims.RealmAccess["roles"], allowedRoles)
+		ok := Overlap(claims.RealmAccess["roles"], allowedRoles)
 		if !ok {
 			return c.JSON(http.StatusUnauthorized, "user is not authorized")
 		}

--- a/blobstore/buckets.go
+++ b/blobstore/buckets.go
@@ -93,7 +93,8 @@ func (bh *BlobHandler) HandleListBuckets(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, fmt.Errorf("error fetching user permissions: %s", err.Error()))
 	}
 
-	for _, controller := range bh.S3Controllers {
+	for i := range bh.S3Controllers {
+		controller := &bh.S3Controllers[i]
 		if bh.AllowAllBuckets {
 			result, err := controller.ListBuckets()
 			if err != nil {

--- a/blobstore/list.go
+++ b/blobstore/list.go
@@ -104,6 +104,10 @@ func (bh *BlobHandler) HandleListByPrefix(c echo.Context) error {
 		}
 		for _, object := range page.Contents {
 			// Handle files
+			// Skip zero-byte objects that match a common prefix with a trailing slash
+			if *object.Size == 0 && strings.HasSuffix(*object.Key, "/") {
+				continue
+			}
 			if fullAccess || IsPermittedPrefix(bucket, *object.Key, permissions) {
 				result = append(result, aws.StringValue(object.Key))
 			}
@@ -185,6 +189,10 @@ func (bh *BlobHandler) HandleListByPrefixWithDetail(c echo.Context) error {
 
 		for _, object := range page.Contents {
 			// Handle files
+			// Skip zero-byte objects that match a common prefix with a trailing slash
+			if *object.Size == 0 && strings.HasSuffix(*object.Key, "/") {
+				continue
+			}
 			if fullAccess || IsPermittedPrefix(bucket, *object.Key, permissions) {
 				file := ListResult{
 					ID:         count,

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	e.PUT("/object/move", auth.Authorize(bh.HandleMoveObject, admin...))
 	e.GET("/object/download", auth.Authorize(bh.HandleGetPresignedDownloadURL, allUsers...))
 	e.POST("/object/upload", auth.Authorize(bh.HandleMultipartUpload, writers...)) //deprecated by presigned upload URL
-	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, admin...))
+	e.DELETE("/object/delete", auth.Authorize(bh.HandleDeleteObject, writers...))
 	e.GET("/object/exists", auth.Authorize(bh.HandleGetObjExist, allUsers...))
 	e.GET("/object/presigned_upload", auth.Authorize(bh.HandleGetPresignedUploadURL, writers...))
 	e.GET("/object/multipart_upload_id", auth.Authorize(bh.HandleGetMultipartUploadID, writers...))
@@ -104,7 +104,7 @@ func main() {
 	e.GET("/prefix/size", auth.Authorize(bh.HandleGetSize, allUsers...))
 
 	// universal
-	e.DELETE("/delete_keys", auth.Authorize(bh.HandleDeleteObjectsByList, admin...))
+	e.DELETE("/delete_keys", auth.Authorize(bh.HandleDeleteObjectsByList, writers...))
 
 	// multi-bucket
 	e.GET("/list_buckets", auth.Authorize(bh.HandleListBuckets, allUsers...))

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	// e.GET("/prefix/download", auth.Authorize(bh.HandleGetPresignedURLMultiObj, allUsers...))
 	e.GET("/prefix/download/script", auth.Authorize(bh.HandleGenerateDownloadScript, allUsers...))
 	e.PUT("/prefix/move", auth.Authorize(bh.HandleMovePrefix, admin...))
-	e.DELETE("/prefix/delete", auth.Authorize(bh.HandleDeletePrefix, admin...))
+	e.DELETE("/prefix/delete", auth.Authorize(bh.HandleDeletePrefix, writers...))
 	e.GET("/prefix/size", auth.Authorize(bh.HandleGetSize, allUsers...))
 
 	// universal


### PR DESCRIPTION
Skip zero-byte objects that match a common prefix with a trailing slash. These objects are created as placeholders when users create directories directly within the AWS S3 console and cause errors. 